### PR TITLE
Make declarations in hardware.c consistent with hardware.h

### DIFF
--- a/tools/hardware.c
+++ b/tools/hardware.c
@@ -5,9 +5,9 @@
 #include "hardware.h"
 #include "pins.h"
 
-int hw_maxtracks = HW_MAXTRACKS;
-int hw_currenttrack = 0;
-int hw_currenthead = 0;
+unsigned int hw_maxtracks = HW_MAXTRACKS;
+unsigned int hw_currenttrack = 0;
+unsigned int hw_currenthead = 0;
 unsigned long hw_samplerate = 0;
 float hw_rpm = HW_DEFAULTRPM;
 


### PR DESCRIPTION
Changed the following to in hardware.c to be unsigned int

- hw_maxtracks
- hw_currenttrack
- hw_samplerate 

This matches the header file declaration in hardware.h 

It was previously failing to compile on the following:
- Raspberry Pi 3 Model B Rev 1.2
- gcc 8.3.0
- Raspbian 10 (buster)
- Linux raspberrypi 5.4.51-v7+ #1327 SMP Thu Jul 23 10:58:46 BST 2020 armv7l GNU/Linux