### PR TITLE
Add support for Double Density BBC DFS Disks (Solidisk Tested)

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -8,7 +8,7 @@ REVISION = $(shell bash ./hw.sh Revision)
 DEBUGFLAGS = -g -W -Wall
 BUILDFLAGS = $(DEBUGFLAGS) -D$(HARDWARE) -D$(REVISION)
 
-all: drivetest bbcfdc checkfsd checktd0 checkscp
+all: drivetest bbcfdc checkfsd checktd0 checkscp bbcfdc-nopi
 
 drivetest: drivetest.o hardware.o
 	$(CC) $(BUILDFLAGS) -o drivetest drivetest.o hardware.o -lbcm2835

--- a/tools/README.md
+++ b/tools/README.md
@@ -21,7 +21,7 @@ Also output to **.dfi** (DiscFerret flux dump) is possible (not tested).
  * `-spidiv` Specify SPI clock divider to adjust sample rate (one of 16,32,64)
  * `-r` Specify number of retries per track when less than expected sectors are found (not in .rfi, .dfi, .scp or .raw)
  * `-l` Show a layout diagram of where sectors were found upon the disk surface for each track/side
- * `-ss` Force single-sided capture
+ * `-ss` Force single-sided capture - optionally adding a 0 or 1 afterwards chooses that side e.g. `-ss 0` or `-ss 1`
  * `-ds` Force double-sided capture (unless output is to .ssd)
  * `-sectors` force DFS sectors e.g. 16 for Solidisk / Watford double density
  * `-sort` Sort sectors in diskstore prior to writing image

--- a/tools/README.md
+++ b/tools/README.md
@@ -26,6 +26,7 @@ Also output to **.dfi** (DiscFerret flux dump) is possible (not tested).
  * `-sectors` force DFS sectors e.g. 16 for Solidisk / Watford double density
  * `-sort` Sort sectors in diskstore prior to writing image
  * `-summary` Present a summary of operations once complete
+ * `-csv` Create a csv of bad sectors named as <outputfile>.csv
  * `-tmax` Specify the maximum track number you wish to try stepping to
  * `-title` Override the title used in metadata for disk formats which support it (.td0 / .fsd)
  * `-v` Verbose
@@ -118,9 +119,8 @@ It will check for the .td0 magic identifier, show the header details, decompress
 ## BBC DFS Notes:
  * Using a `.ddd` or `.sdd` output file for BBC DFS disks will assume 16 sectors per track (i.e. double density)
  * Above can be overriden with the `-sectors` switch e.g. `-sectors 18`
- * Disks with different densities on different sides cannot currently be captured into `.ddd` (watch this space)
- * Better for the code to ultimately use the mod_density flag to auto detect the densities (maybe in the future)
- * Not currently possible to just capture the second side of the disk - can just capture the first side (watch this space)
+ * Disks with different densities on different sides cannot currently be captured into `.ddd`
+ * If a Solidisk chained catalogue is detected, it will notify during the catalogue operaton but not list it
 
  
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -17,12 +17,13 @@ Also output to **.dfi** (DiscFerret flux dump) is possible (not tested).
 
  * `-i` Specify input **.rfi** file (when not being run on RPi hardware)
  * `-c` Catalogue the disk contents (DFS/ADFS/DOS only)
- * `-o` Specify output file, with one of the following extensions (.rfi, .dfi, .scp, .ssd, .dsd, .fsd, .td0, .img, .adf)
+ * `-o` Specify output file, with one of the following extensions (.rfi, .dfi, .scp, .sdd, .ssd, .ddd, .dsd, .fsd, .td0, .img, .adf)
  * `-spidiv` Specify SPI clock divider to adjust sample rate (one of 16,32,64)
  * `-r` Specify number of retries per track when less than expected sectors are found (not in .rfi, .dfi, .scp or .raw)
  * `-l` Show a layout diagram of where sectors were found upon the disk surface for each track/side
  * `-ss` Force single-sided capture
  * `-ds` Force double-sided capture (unless output is to .ssd)
+ * `-sectors` force DFS sectors e.g. 16 for Solidisk / Watford double density
  * `-sort` Sort sectors in diskstore prior to writing image
  * `-summary` Present a summary of operations once complete
  * `-tmax` Specify the maximum track number you wish to try stepping to
@@ -113,3 +114,14 @@ It will check for the .td0 magic identifier, show the header details, decompress
  * `8` - Unable to read sector data
  * `9` - Unable to allocate memory for decompression
  * `10` - Sector data CRC mismatch
+
+## BBC DFS Notes:
+ * Using a `.ddd` or `.sdd` output file for BBC DFS disks will assume 16 sectors per track (i.e. double density)
+ * Above can be overriden with the `-sectors` switch e.g. `-sectors 18`
+ * Disks with different densities on different sides cannot currently be captured into `.ddd` (watch this space)
+ * Better for the code to ultimately use the mod_density flag to auto detect the densities (maybe in the future)
+ * Not currently possible to just capture the second side of the disk - can just capture the first side (watch this space)
+
+ 
+
+

--- a/tools/bbcfdc.c
+++ b/tools/bbcfdc.c
@@ -64,6 +64,7 @@ unsigned long samplebuffsize;
 int flippy=0;
 int info=0;
 int layout=0;
+int sidetoread=-1;
 
 // Processing position within the SPI buffer
 unsigned long datapos=0;
@@ -222,10 +223,15 @@ int main(int argc,char **argv)
     else
     if (strcmp(argv[argn], "-ss")==0)
     {
+      unsigned int retval;
       printf("Forced single-sided capture\n");
 
       // Request single-sided
       sides=1;
+
+      ++argn;
+      if (sscanf(argv[argn], "%3d", &retval)==1)
+        sidetoread=retval;
     }
     else
     if (strcmp(argv[argn], "-csv")==0)
@@ -766,6 +772,11 @@ int main(int argc,char **argv)
     // Process all available disk sides (heads)
     for (side=0; side<sides; side++)
     {
+      // Read the correct side if in single side read mode
+      if(sidetoread != -1) 
+      {
+        side=sidetoread;
+      }
       // Select the correct side
       hw_sideselect(side);
 
@@ -1056,6 +1067,10 @@ int main(int argc,char **argv)
       {
         for (imgside=0; imgside<sides; imgside++)
         {
+	  if(sidetoread!=-1)
+	  {
+            imgside=sidetoread;
+	  }
           for (j=0; j<dfssectorspertrack; j++)
           {
             // Write

--- a/tools/bbcfdc.c
+++ b/tools/bbcfdc.c
@@ -139,7 +139,7 @@ void showargs(const char *exename)
 #ifdef NOPI
   fprintf(stderr, "[-i input_rfi_file] ");
 #endif
-  fprintf(stderr, "[[-c] | [-o output_file]] [-spidiv spi_divider] [[-ss]|[-ds]] [-r retries] [-sort] [-sectors dfs_sectors_per_track] [-summary] [-tmax maxtracks] [-l] [-title \"Title\"] [-v]\n");
+  fprintf(stderr, "[[-c] | [-o output_file]] [-spidiv spi_divider] [[-ss]|[-ds]] [-r retries] [-sort] [-sectors dfs_sectors_per_track] [-summary] [-csv] [-tmax maxtracks] [-l] [-title \"Title\"] [-v]\n");
 }
 
 int main(int argc,char **argv)

--- a/tools/bbcfdc.c
+++ b/tools/bbcfdc.c
@@ -231,7 +231,13 @@ int main(int argc,char **argv)
 
       ++argn;
       if (sscanf(argv[argn], "%3d", &retval)==1)
+      {
         sidetoread=retval;
+      }
+      else
+      {
+        --argn;
+      }
     }
     else
     if (strcmp(argv[argn], "-csv")==0)

--- a/tools/bbcfdc.c
+++ b/tools/bbcfdc.c
@@ -948,8 +948,8 @@ int main(int argc,char **argv)
      // List the failed sectors so they are all listed together
      // and list as a CSV for ease of import into a spreadsheet
      // BBC DFS images only... 
-     if ((outputtype!=IMAGEDSD) || (outputtype!=IMAGESSD) ||
-        (outputtype!=IMAGEDDD) || (outputtype!=IMAGESDD) ) 
+     if ((outputtype==IMAGEDSD) || (outputtype==IMAGESSD) ||
+        (outputtype==IMAGEDDD) || (outputtype==IMAGESDD) ) 
      {
         if(capturetype != DISKCAT) 
 	{

--- a/tools/dfs.c
+++ b/tools/dfs.c
@@ -124,13 +124,14 @@ void dfs_gettitle(const int head, char *title, const int titlelen)
   }
 }
 
-void dfs_showinfo(const int head)
+
+void dfs_showinfo(const int head, const unsigned int disktracks, const unsigned int sectorspertrack)
 {
   int i;
   int numfiles;
   int locked;
   unsigned char bootoption;
-  size_t tracks, totalusage, totalsectors, totalsize, sectorusage;
+  size_t totalusage, totalsectors, totalsize, sectorusage, calcsize;
   char filename[10];
   Disk_Sector *sector0;
   Disk_Sector *sector1;
@@ -160,41 +161,44 @@ void dfs_showinfo(const int head)
   }
   printf("\"\n");
 
-  totalsectors=(((sector1->data[6]&0x03)<<8) | (sector1->data[7]));
-  tracks=totalsectors/DFS_SECTORSPERTRACK;
-  totalsize=totalsectors*DFS_SECTORSIZE;
-  printf("Disk size : %lu tracks (%u sectors, %lu bytes)\n", (unsigned long)tracks, (unsigned int)totalsectors, (unsigned long)totalsize);
+  // On some DDFS filesystems, bit 3 is also used of byte 6 to provide an 11-bit 
+  // disk size instead of the standard Acorn DFS 10-bit disk size - Acorn DFS always 
+  // sets bit 3 to zero so extended this to bit 3 doesn't hurt Acorn DFS 
+  totalsectors=(((sector1->data[6]&0x07)<<8) | (sector1->data[7])); 
+  
+  // Don't calculate this as we already worked it previously 
+  // from the hardware - commented out for posterity 
+  // tracks=totalsectors/dfsSectorsPerTrack; 
+  
+  totalsize=totalsectors*DFS_SECTORSIZE; 
+  printf("Disk size : %lu tracks (%u sectors, %lu bytes)\n", (unsigned long)disktracks, (unsigned int)totalsectors, (unsigned long)totalsize); 
+  bootoption=(sector1->data[6]&0x30)>>4; 
+  printf("Boot option: %d ", bootoption); 
 
-  bootoption=(sector1->data[6]&0x30)>>4;
-  printf("Boot option: %d ", bootoption);
-  switch (bootoption)
-  {
-    case 0:
-      printf("Nothing");
-      break;
 
-    case 1:
-      printf("*LOAD !BOOT");
-      break;
-
-    case 2:
-      printf("*RUN !BOOT");
-      break;
-
-    case 3:
-      printf("*EXEC !BOOT");
-      break;
-
-    default:
-      printf("Unknown");
-      break;
-  }
-  printf("\n");
-
-  totalusage=0; sectorusage=2;
-  printf("Write operations made to disk : %.2x\n", sector1->data[4]); // Stored in BCD
-
-  numfiles=sector1->data[5]/8;
+  switch (bootoption) { 
+     case 0: 
+        printf("Nothing"); 
+	break; 
+     case 1: 
+	printf("*LOAD !BOOT"); 
+	break; 
+     case 2: 
+	printf("*RUN !BOOT"); 
+	break; 
+     case 3: 
+	printf("*EXEC !BOOT"); 
+	break; 
+     default: 
+	printf("Unknown"); 
+	break; 
+  } 
+  printf("\n"); 
+  
+  totalusage=0; sectorusage=2; 
+  printf("Write operations made to disk : %.2x\n", sector1->data[4]); // Stored in BCD 
+  
+  numfiles=sector1->data[5]/8; 
   printf("Catalogue entries : %d\n", numfiles);
 
   for (i=1; ((i<=numfiles) && (i<DFS_MAXFILES)); i++)
@@ -214,11 +218,26 @@ void dfs_showinfo(const int head)
   }
 
   printf("Total disk usage : %lu bytes (%ld%% of disk)\n", (unsigned long)totalusage, (totalusage*100)/(totalsize-(2*DFS_SECTORSIZE)));
-  printf("Remaining catalogue space : %d files, %ld unused disk sectors\n", DFS_MAXFILES-numfiles, (((sector1->data[6]&0x03)<<8) | (sector1->data[7])) - sectorusage);
+  // Use bits 0-2 of byte 6 to cater for 11-bit double density sizes
+  // Acorn DFS will always set to zero - so & with 0x07 not 0x03
+  printf("Remaining catalogue space : %d files, %ld unused disk sectors\n", DFS_MAXFILES-numfiles, (((sector1->data[6]&0x07)<<8) | (sector1->data[7])) - sectorusage);
+  calcsize = disktracks * sectorspertrack * DFS_SECTORSIZE;
+  printf("Disk tracks %d, sectors %d\n", disktracks, sectorspertrack);
+  if( calcsize > totalsize ) {
+      printf("\nWARNING: Disk catalogue size %d is SMALLER than disk size %d\n", totalsize, calcsize);
+      printf("WARNING: Catatlogue sectors per track %d but bbcfdc sectors per track %d\n", totalsectors/disktracks, sectorspertrack); 
+      printf("WARNING: If you try and create a DFS image try using switch -sectors %d\n", sectorspertrack);
+  } else if( calcsize< totalsize ) {
+      printf("\nWARNING: Disk catalogue size %d is BIGGER than disk size %d \n", totalsize, calcsize);
+      printf("WARNING: Catatlogue sectors per track %d but bbcfdc sectors per track %d\n", totalsectors/disktracks, sectorspertrack); 
+      printf("WARNING: If you try and create a DFS image try using switch -sectors %d\n", totalsectors/disktracks);
+  }
 }
 
+
+
 // Test for valid DFS catalogue, checks from http://beebwiki.mdfs.net/Acorn_DFS_disc_format
-int dfs_validcatalogue(const int head)
+int dfs_validcatalogue(const int head, unsigned int* totalsectors)
 {
   Disk_Sector *sector0;
   Disk_Sector *sector1;
@@ -245,12 +264,23 @@ int dfs_validcatalogue(const int head)
 
   // Check reserved bits
   if ((sector1->data[5]&0x07)!=0) return 0;
+  
   if ((sector1->data[6]&0xc0)!=0) return 0;
-  if ((sector1->data[6]&0x0c)!=0) return 0;
+
+  // On some double density DFS systems, bits 0-2 are used to make an 11 bit 
+  // disk size in byte 6 rather than the standard single density Acorn DFS which
+  // only uses bits 0-1 - so only do this check if it's single density
+  // (10 sectors per track) DFS. Regardless, bit 3 should be set to 0.
+  // The original check stopped DDFS disks being catalogued - which meant you
+  // couldn't check their total sectors.  Original check was against 0x0C (00001100)
+  if ((sector1->data[6]&0x08)!=0) return 0;
 
   // TODO check that the disk size is between 2 and 800 sectors (maybe also up to 1023)
-  if ((((sector1->data[6]&0x03)<<8) | (sector1->data[7]))<1)
+  if ((((sector1->data[6]&0x07)<<8) | (sector1->data[7]))<1)
     return 0;
+
+  *totalsectors = (((sector1->data[6]&0x07)<<8) | (sector1->data[7]));
+  printf("Catalogue has %d sectors\n", *totalsectors);
 
   // TODO check the title contains printable ASCII padded with NULs or spaces
 

--- a/tools/dfs.c
+++ b/tools/dfs.c
@@ -135,6 +135,7 @@ void dfs_showinfo(const int head, const unsigned int disktracks, const unsigned 
   char filename[10];
   Disk_Sector *sector0;
   Disk_Sector *sector1;
+  Disk_Sector *sectorn;
 
   // Search for sectors
   sector0=diskstore_findhybridsector(0, head, 0);
@@ -215,6 +216,14 @@ void dfs_showinfo(const int head, const unsigned int disktracks, const unsigned 
 
     if (locked) printf(" L");
     printf("\n");
+  }
+
+  // Check to see if this is a Solidisk disk with a chained catalogue
+  // If it is then the top two bits of byte 2 in sector 1 will be set
+  if((sector1->data[2]&0xC0) == 0xC0)
+  {
+    printf("Solidisk chained catalogue detected (not listed)\n");
+    printf("Second Solidisk catalogue in at sector %.4x\n", ((sector1->data[2]&0x3F)<<8) | (sector1->data[3]));
   }
 
   printf("Total disk usage : %lu bytes (%ld%% of disk)\n", (unsigned long)totalusage, (totalusage*100)/(totalsize-(2*DFS_SECTORSIZE)));

--- a/tools/dfs.h
+++ b/tools/dfs.h
@@ -4,6 +4,7 @@
 // Acorn DFS geometry and layout
 #define DFS_SECTORSIZE 256
 #define DFS_SECTORSPERTRACK 10
+#define DFS_DDSECTORSPERTRACK 16
 #define DFS_TRACKSIZE (DFS_SECTORSIZE*DFS_SECTORSPERTRACK)
 
 #define DFS_MAXTRACKS 80
@@ -14,7 +15,7 @@
 #define DFS_MAXFILES 31
 
 extern void dfs_gettitle(const int head, char *title, const int titlelen);
-extern void dfs_showinfo(const int head);
-extern int dfs_validcatalogue(const int head);
+extern void dfs_showinfo(const int head, const unsigned int disktracks, const unsigned int sectorspertrack);
+extern int dfs_validcatalogue(const int head,unsigned int* sectorspertrack);
 
 #endif

--- a/tools/diskstore.c
+++ b/tools/diskstore.c
@@ -376,7 +376,7 @@ void diskstore_dumpbadsectors(FILE* fh)
 
   fprintf(fh, "Head, Track, Sector\n");
 
-  for (dhead=0; dhead<2; dhead++)
+  for (dhead=0; dhead<(diskstore_maxhead+1); dhead++)
   {
     for (dtrack=0; dtrack<(diskstore_maxtrack+1); dtrack+=hw_stepping)
     {

--- a/tools/diskstore.c
+++ b/tools/diskstore.c
@@ -369,6 +369,29 @@ void diskstore_dumpsectorlist()
   fprintf(stderr, "Total extracted sectors: %d\n", totalsectors);
 }
 
+// Dump a list of all sectors found
+void diskstore_dumpbadsectors(FILE* fh)
+{
+  int dtrack, dhead,dsector;
+
+  fprintf(fh, "Head, Track, Sector\n");
+
+  for (dhead=0; dhead<2; dhead++)
+  {
+    for (dtrack=0; dtrack<(diskstore_maxtrack+1); dtrack+=hw_stepping)
+    {
+      for(dsector=0; dsector<(diskstore_maxsectorid+1); dsector++)
+      {
+         if(diskstore_findhybridsector(dtrack, dhead, dsector)==NULL)
+	 {
+            fprintf(fh, "%.2X, %.2X, %.2X\n", dhead, dtrack, dsector);
+	 }
+      }
+    }
+  }
+
+}
+
 // Dump a layout map of where data was found on the disk surface
 void diskstore_dumplayoutmap(const int rotations)
 {

--- a/tools/diskstore.h
+++ b/tools/diskstore.h
@@ -75,6 +75,7 @@ extern void diskstore_sortsectors();
 
 // Dump the contents of the disk storage for debug purposes
 extern void diskstore_dumpsectorlist();
+extern void diskstore_dumpbadsectors(FILE* fh);
 extern void diskstore_dumplayoutmap(const int rotations);
 
 // Absolute data access


### PR DESCRIPTION
The following changes were introduction (the reporting was an logical outcome from debugging to make sure everything was captured successfully):

1. Added support for DDD files which can be loaded by B-em, B2 and MAME
2. Added support for SDD files which can be loaded by B-em, B2 and MAME
3. Add -sectors switch to allow manual setting for sectors for DFS format capture
4. Added ability to read and copy Solidisk DDFS disks
5. Defaults to 16 sectors per track if DDD is specified
6. Defaults to 16 sectors per track if SDD is specified
7. Correctly reads 10-bit and 11-bit sector counts (high bits in byte 6/sector 1)
8. Warns user if cataloguing a DFS disk that they may have to use -sectors
9. Eased DFS sector 1 checks to allow Watford / Solidsk disks to pass the byte 6 checks
10. Generates a CSV friendly list at the end of every failed track (useful if you are trying different drives and want to merge from different successfuly sources)
11. Writes CSV data to <output file>
12. Using a DDD or SDD output file auto switches to 16 sectors per track  UNLESS -sectors has been set
13. Allow checking of more than 10 sectors in bbcfdc (main loop was hardcoded to 10 as per single density Acorn format)
14. Detects Solidisk chained catalogues (does not catalogue them yet as they require additional sector reads) and outputs a message during the catalogue operation
15. Added bbcfdc-nopi as a target for the "all" target in the makefile - seems convenient to have this is e.g. you are capturing RFI files and then want to make a BBC image from them 
16. Added ability to optionally specific which side after the -ss flag e.g. -ss 1 to allow ability to rip the second side of a BBC disk only if for example the first side is corrupt or in a different density to the first side.

