### PR TITLE
No dependence on bash

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -2,9 +2,9 @@
 
 CC = gcc
 
-HARDWARE = $(shell bash ./hw.sh Hardware)
-REVISION = $(shell bash ./hw.sh Revision)
-CPU = $(shell bash ./hw.sh CPU)
+HARDWARE = $(shell sh ./hw.sh Hardware)
+REVISION = $(shell sh ./hw.sh Revision)
+CPU = $(shell sh ./hw.sh CPU)
 
 DEBUGFLAGS = -g -W -Wall
 BUILDFLAGS = $(DEBUGFLAGS) -D$(HARDWARE) -D$(REVISION)

--- a/tools/hw.sh
+++ b/tools/hw.sh
@@ -7,7 +7,7 @@
 revision=$(cat /proc/cpuinfo | grep "Revision" | sed 's/.*: //')
 
 # Convert to decimal
-revision=$((16#$revision))
+revision=$(printf "%d\n" 0x$revision)
 
 # Strip off top 8 bits - Overvotage/OTP/Warranty
 revision=$(($revision & 0xffffff))


### PR DESCRIPTION
Your `Makefile` and `hw.sh` are dependent on bash. Some distros don't use bash, but for example busybox. In that case, your project is not buildable.
This dependency is simply solved by this pull request.